### PR TITLE
grpc-interceptor 0.15.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grpc-interceptor-{{ version }}.tar.gz
-  sha256: 1f45c0bcb58b6f332f37c637632247c9b02bc6af0fdceb7ba7ce8d2ebbfb0926
+  #url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grpc-interceptor-{{ version }}.tar.gz
+  #sha256: 1f45c0bcb58b6f332f37c637632247c9b02bc6af0fdceb7ba7ce8d2ebbfb0926
+  url: https://github.com/d5h-foss/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 382a2a1a18e40929f2ef635c06f16e32e6c2927293484368114cf1fd14aaa81a
 
 build:
   skip: True  # [py<37]
@@ -25,12 +27,18 @@ requirements:
     - protobuf >=4.21.9
 
 test:
+  source_files:
+    - tests
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -vv tests
   requires:
     - pip
     - python
+    - pytest
+    - protobuf >=4.21.9
+    - pytest-asyncio >=0.19.0
 
 about:
   home: https://github.com/d5h-foss/grpc-interceptor

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  #url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grpc-interceptor-{{ version }}.tar.gz
-  #sha256: 1f45c0bcb58b6f332f37c637632247c9b02bc6af0fdceb7ba7ce8d2ebbfb0926
   url: https://github.com/d5h-foss/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 382a2a1a18e40929f2ef635c06f16e32e6c2927293484368114cf1fd14aaa81a
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   skip: True  # [py<37]
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
@@ -19,7 +18,6 @@ requirements:
   host:
     - python
     - poetry-core >=1.0.0
-    - pip
   run:
     - python
     - grpcio >=1.49.1,<2.0.0
@@ -27,8 +25,6 @@ requirements:
     - protobuf >=4.21.9
 
 test:
-  imports:
-    - grpc_interceptor
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,18 @@ source:
   sha256: 1f45c0bcb58b6f332f37c637632247c9b02bc6af0fdceb7ba7ce8d2ebbfb0926
 
 build:
+  skip: True  # [py<37]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - poetry-core >=1.0.0
     - pip
   run:
-    - python >={{ python_min }},<4.0.0
+    - python
     - grpcio >=1.49.1,<2.0.0
   run_constrained:
     - protobuf >=4.21.9
@@ -30,9 +31,10 @@ test:
     - grpc_interceptor
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   requires:
     - pip
-    - python {{ python_min }}
+    - python
 
 about:
   home: https://github.com/d5h-foss/grpc-interceptor


### PR DESCRIPTION
grpc-interceptor 0.15.4 

**Destination channel:** Defaults

### Links

- [PKG-8623]
- dev_url:        https://github.com/d5h-foss/grpc-interceptor/tree/v0.15.4
- conda_forge:    https://github.com/conda-forge/grpc-interceptor-feedstock
- pypi:           https://pypi.org/project/grpc-interceptor/0.15.4
- pypi inspector: https://inspector.pypi.io/project/grpc-interceptor/0.15.4

### Explanation of changes:

- new version number


[PKG-8623]: https://anaconda.atlassian.net/browse/PKG-8623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ